### PR TITLE
Remove reflow-maven-skin velocity dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- - Copyright 2014-2021 Polago AB.
+ - Copyright 2014-2022 Polago AB.
  -
  - Licensed under the Apache License, Version 2.0 (the "License");
  - you may not use this file except in compliance with the License.
@@ -289,17 +289,6 @@
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-ssh</artifactId>
               <version>3.5.1</version>
-            </dependency>
-            <!-- reflow-maven-skin -->
-            <dependency>
-              <groupId>lt.velykis.maven.skins</groupId>
-              <artifactId>reflow-velocity-tools</artifactId>
-              <version>1.1.1</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.velocity</groupId>
-              <artifactId>velocity</artifactId>
-              <version>1.7</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
The reflow-maven-skin skin is no longer used

This fixes #75 and dependabot alert 1