### PR TITLE
Remove maven prerequisites in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,6 @@
     <resourcesPluginVersion>3.2.0</resourcesPluginVersion>
   </properties>
 
-  <prerequisites>
-    <maven>${mavenVersion}</maven>
-  </prerequisites>
-
   <inceptionYear>2014</inceptionYear>
 
   <licenses>


### PR DESCRIPTION
The maven prerequisites is only intended for maven-plugin projects